### PR TITLE
Backup Hooks

### DIFF
--- a/src/com/exolius/simplebackup/BackupHooks.java
+++ b/src/com/exolius/simplebackup/BackupHooks.java
@@ -1,0 +1,15 @@
+package com.exolius.simplebackup;
+
+public class BackupHooks {
+
+    public void notifyBackupCreated(String command, String filename) {
+       if(!command.isEmpty()) {
+	  try {
+	    ProcessBuilder pb = new ProcessBuilder(command, filename);
+	    pb.start();
+	  } catch(Exception ex) {
+	    
+	  }
+       }
+    }
+}

--- a/src/com/exolius/simplebackup/CopyBackup.java
+++ b/src/com/exolius/simplebackup/CopyBackup.java
@@ -12,14 +12,14 @@ public class CopyBackup extends BackupFileManager {
     }
 
     @Override
-    public Date createBackup(Iterable<File> worldFolders) throws IOException {
+    public String createBackup(Iterable<File> worldFolders) throws IOException {
         Date date = new Date();
         File destination = new File(backupFolder, getFileName(date));
         for (File worldFolder : worldFolders) {
             logger.info("Backing up " + worldFolder);
             FileUtils.copyFiles(worldFolder, new File(destination, worldFolder.getName()), logger);
         }
-        return date;
+        return destination.getAbsolutePath();
     }
 
     @Override

--- a/src/com/exolius/simplebackup/IBackupFileManager.java
+++ b/src/com/exolius/simplebackup/IBackupFileManager.java
@@ -6,7 +6,7 @@ import java.util.Date;
 import java.util.SortedSet;
 
 public interface IBackupFileManager {
-    Date createBackup(Iterable<File> worldFolders) throws IOException;
+    String createBackup(Iterable<File> worldFolders) throws IOException;
     SortedSet<Date> backupList();
     void deleteBackup(Date date) throws IOException;
 }

--- a/src/com/exolius/simplebackup/SimpleBackup.java
+++ b/src/com/exolius/simplebackup/SimpleBackup.java
@@ -27,6 +27,7 @@ public class SimpleBackup extends JavaPlugin {
     private String backupFile = "backups/";
     private String customMessage = "Backup starting";
     private String customMessageEnd = "Backup completed";
+    private String backupCommand = "";
 
     private List<String> backupWorlds;
     private List<String> additionalFolders;
@@ -35,6 +36,7 @@ public class SimpleBackup extends JavaPlugin {
 
     protected FileConfiguration config;
     private final LoginListener loginListener = new LoginListener();
+    private final BackupHooks backupHooks= new BackupHooks();
 
     /*----------------------------------------
      This is ran when the plugin is disabled
@@ -107,6 +109,7 @@ public class SimpleBackup extends JavaPlugin {
         message = config.getString("backup-message");
         customMessage = config.getString("custom-backup-message");
         customMessageEnd = config.getString("custom-backup-message-end");
+	backupCommand = config.getString("backup-completed-hook");
         disableZipping = config.getBoolean("disable-zipping");
         selfPromotion = config.getBoolean("self-promotion");
         String startTime = config.getString("start-time");
@@ -176,8 +179,9 @@ public class SimpleBackup extends JavaPlugin {
         foldersToBackup.addAll(foldersForBackup());
 
         // zip/copy world folders
+	String backupFile = null;
         try {
-            backupFileManager.createBackup(foldersToBackup);
+            backupFile = backupFileManager.createBackup(foldersToBackup);
         } catch (IOException e) {
             getLogger().log(Level.WARNING, e.getMessage(), e);
         }
@@ -198,7 +202,10 @@ public class SimpleBackup extends JavaPlugin {
         if (broadcast) {
             getServer().broadcastMessage(ChatColor.BLUE + message + " " + customMessageEnd);
         }
-        loginListener.notifyBackupCreated();
+	if(backupFile != null) {
+	   loginListener.notifyBackupCreated();
+	   backupHooks.notifyBackupCreated(backupCommand, backupFile);
+	}
     }
 
     private Collection<File> foldersForBackup() {

--- a/src/com/exolius/simplebackup/ZipBackup.java
+++ b/src/com/exolius/simplebackup/ZipBackup.java
@@ -15,7 +15,7 @@ public class ZipBackup extends BackupFileManager {
     }
 
     @Override
-    public Date createBackup(Iterable<File> worldFolders) throws IOException {
+    public String createBackup(Iterable<File> worldFolders) throws IOException {
         if (!backupFolder.exists()) {
             backupFolder.mkdirs();
         }
@@ -34,7 +34,7 @@ public class ZipBackup extends BackupFileManager {
                 logger.log(Level.FINE, e.getMessage(), e);
             }
         }
-        return date;
+        return backupFile.getAbsolutePath();
     }
 
     @Override

--- a/src/config.yml
+++ b/src/config.yml
@@ -83,3 +83,4 @@ broadcast-message: true
 backup-message: '[SimpleBackup]'
 custom-backup-message: Backup starting
 custom-backup-message-end: Backup completed
+backup-completed-hook: ''


### PR DESCRIPTION
I found myself wanting to copy all backed up files to a different server for obvious reasons, but I also realized that I might get only 'partial' files if my backup script ran at the same time as your plugin.

The solution, of course, was to modify your plugin to run a configurable command on completion. If the new config option, for example, were set to '/home/minecraft/scp-backup.sh' containing 'scp $@ remoteBackupServer:backups' then this should copy all files over to my backup server. There are more applications obviously, but offsite copies seems like a useful one.

Default behavior is to do nothing so that it doesn't get in the way if you don't want it.

Cheers!
