### PR TITLE
Fixed "Asynchronous entity track"

### DIFF
--- a/src/com/exolius/simplebackup/SimpleBackup.java
+++ b/src/com/exolius/simplebackup/SimpleBackup.java
@@ -201,7 +201,11 @@ public class SimpleBackup extends JavaPlugin {
 
         // Broadcast the backup completion if enabled
         if (broadcast) {
-            getServer().broadcastMessage(ChatColor.BLUE + message + " " + customMessageEnd);
+        	getServer().getScheduler().runTask(this, new Runnable(){
+				@Override
+				public void run() {
+					getServer().broadcastMessage(ChatColor.BLUE + message + " " + customMessageEnd);
+				}});
         }
         loginListener.notifyBackupCreated();
     }

--- a/src/com/exolius/simplebackup/SimpleBackup.java
+++ b/src/com/exolius/simplebackup/SimpleBackup.java
@@ -72,7 +72,7 @@ public class SimpleBackup extends JavaPlugin {
         if (ticks > 0) {
             long delay = this.startHour != null ? syncStart(this.startHour) : ticks;
             // Add the repeating task, set it to repeat the specified time
-            this.getServer().getScheduler().scheduleAsyncRepeatingTask(this, new Runnable() {
+            this.getServer().getScheduler().runTaskTimerAsynchronously(this, new Runnable() {
                 @Override
                 public void run() {
                     // When the task is run, start the map backup
@@ -154,7 +154,11 @@ public class SimpleBackup extends JavaPlugin {
         // Begin backup of worlds
         // Broadcast the backup initialization if enabled
         if (broadcast) {
-            getServer().broadcastMessage(ChatColor.BLUE + message + " " + customMessage);
+        	getServer().getScheduler().runTask(this, new Runnable(){
+				@Override
+				public void run() {
+		            getServer().broadcastMessage(ChatColor.BLUE + message + " " + customMessage);
+				}});
         }
         // Loop through all the specified worlds and save them
         List<File> foldersToBackup = new ArrayList<File>();


### PR DESCRIPTION
Fixed this:

```
[03:00:10 INFO]: [SimpleBackup] Backup starting
[03:00:10 WARN]: Exception in thread "Craft Scheduler Thread - 96"
[03:00:10 WARN]: org.apache.commons.lang.UnhandledException: Plugin SimpleBackup v1.7 generated an exception while executing task 19
        at org.bukkit.craftbukkit.v1_9_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:56)
        [...]
Caused by: java.lang.IllegalStateException: Asynchronous entity track!
        at org.spigotmc.AsyncCatcher.catchOp(AsyncCatcher.java:14)
        at net.minecraft.server.v1_9_R1.EntityTracker.addEntity(EntityTracker.java:105)
        at net.minecraft.server.v1_9_R1.EntityTracker.track(EntityTracker.java:81)
        [...]
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.broadcast(CraftServer.java:1288)
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.broadcastMessage(CraftServer.java:452)
        at com.exolius.simplebackup.SimpleBackup.doBackup(SimpleBackup.java:157)
        at com.exolius.simplebackup.SimpleBackup$1.run(SimpleBackup.java:80)
```