### PR TITLE
remove trailing slash in pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,8 @@
     <dependency>
         <groupId>org.spigotmc</groupId>
         <artifactId>spigot-api</artifactId>
-        <version>1.11.2-R0.1-SNAPSHOT/</version>
+        <version>1.12.2-R0.1-SNAPSHOT</version>
         <scope>provided</scope>
-    </dependency>
-    <!--Bukkit API-->
-    <dependency>
-      <groupId>org.bukkit</groupId>
-      <artifactId>bukkit</artifactId>
-      <version>1.11.2-R0.1-SNAPSHOT/</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
It won't resolve if you do this.

Also bukkit isn't needed if you're depending on spigot.